### PR TITLE
switch build to hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,20 +2,11 @@
 # --- Build system configuration
 
 [build-system]
-requires = [ "setuptools>=41",]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.setuptools-git-versioning]
-enabled = true
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools]
-include-package-data = true
-
-[tool.setuptools_scm]  # this empty section enables the tool
-
+[tool.hatch.build.targets.wheel]
+packages = ["src/unidas.py"]
 
 # --- Project Metadata
 


### PR DESCRIPTION

## Description

The publish to pypi with uv is broken due to [this setuptools bug](https://github.com/pypa/setuptools/issues/4759). This PR tries to switch unidas build system to hatchling to resolve the issue. 

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings or appropriate doc page.
- [ ] included a test.
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.
